### PR TITLE
feat: replace Date.now() with network's height

### DIFF
--- a/CreateNFT/contracts-example/creatingNewNFT.js
+++ b/CreateNFT/contracts-example/creatingNewNFT.js
@@ -15,6 +15,10 @@ const arweave = Arweave.init({
 
 mintNFT();
 
+async function getNetworkBlockHeight() {
+  const network = await arweave.network.getInfo()
+  return network.height
+}
 
 async function mintNFT() {
     console.log('wallet:', process.env.WALLET_LOCATION)
@@ -50,7 +54,7 @@ async function handleData (nftData) {
         },
         "locked": [],
         "contentType": "text/html",
-        "createdAt": Date.now(),
+        "createdAtHeight": await getNetworkBlockHeight(),
         "tags":[]
     }
     let tx = await arweave.createTransaction({


### PR DESCRIPTION
When the `Date` object is used inside the SmartWeave env, that will make the SWC non-deteministic.

Plus, I would suggest replacing any `Date.now()` in a SWC with `SmartWeave.block.height` or `SmartWeave.block.timestamp`